### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 murmgr
 ======
 
-[![Downloads](https://pypip.in/download/murmgr/badge.svg)](https://pypi.python.org/pypi/murmgr/)
-[![Latest Version](https://pypip.in/version/murmgr/badge.svg)](https://pypi.python.org/pypi/murmgr/)
-[![Supported Python versions](https://pypip.in/py_versions/murmgr/badge.svg)](https://pypi.python.org/pypi/murmgr/)
-[![Development Status](https://pypip.in/status/murmgr/badge.svg)](https://pypi.python.org/pypi/murmgr/)
-[![License](https://pypip.in/license/murmgr/badge.svg)](https://pypi.python.org/pypi/murmgr/)
+[![Downloads](https://img.shields.io/pypi/dm/murmgr.svg)](https://pypi.python.org/pypi/murmgr/)
+[![Latest Version](https://img.shields.io/pypi/v/murmgr.svg)](https://pypi.python.org/pypi/murmgr/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/murmgr.svg)](https://pypi.python.org/pypi/murmgr/)
+[![Development Status](https://img.shields.io/pypi/status/murmgr.svg)](https://pypi.python.org/pypi/murmgr/)
+[![License](https://img.shields.io/pypi/l/murmgr.svg)](https://pypi.python.org/pypi/murmgr/)
 
 [![Build Status](https://travis-ci.org/CognitionGuidedSurgery/murmgr.svg?branch=circle)](https://travis-ci.org/CognitionGuidedSurgery/murmgr)
 [![Code Health](https://landscape.io/github/CognitionGuidedSurgery/murmgr/master/landscape.svg)](https://landscape.io/github/CognitionGuidedSurgery/murmgr/master)


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20murmgr))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `murmgr`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.